### PR TITLE
fix overlapping text in tables

### DIFF
--- a/sources/001-v4/sections/section-04/section-02.adoc
+++ b/sources/001-v4/sections/section-04/section-02.adoc
@@ -6193,7 +6193,11 @@ h| 値 h| 説明
 
 ====== IfcStairTypeEnum
 
-[cols="3a,22a"]
+// 20240805 rwp table had overlaps between columns; using auto layout 
+// [cols="3a,22a"]
+
+[cols="a,a"]
+
 |===
 | 列挙型 | IfcStairTypeEnum
 
@@ -6222,7 +6226,10 @@ h| 値 h| 説明
 
 ====== IfcStairFlightTypeEnum
 
-[cols="3a,22a"]
+// 20240805 rwp table had overlaps between columns; using auto layout 
+// [cols="3a,22a"]
+
+[cols="a,a"]
 |===
 | 列挙型 | IfcStairFlightTypeEnum
 
@@ -6243,7 +6250,10 @@ h| 値 h| 説明
 
 ====== IfcStateEnum
 
-[cols="3a,22a"]
+// 20240805 rwp table had overlaps between columns; using auto layout 
+// [cols="3a,22a"]
+
+[cols="a,a"]
 |===
 | 列挙型 | IfcStateEnum
 
@@ -6261,7 +6271,10 @@ h| 値 h| 説明
 
 ====== IfcUnitEnum
 
-[cols="3a,22a"]
+// 20240805 rwp table had overlaps between columns; using auto layout 
+// [cols="3a,22a"]
+
+[cols="a,a"]
 |===
 | 列挙型 | IfcUnitEnum
 
@@ -6304,7 +6317,10 @@ h| 値 h| 説明
 
 ====== IfcTransportElementTypeEnum
 
-[cols="3a,22a"]
+// 20240805 rwp table had overlaps between columns; using auto layout 
+// [cols="3a,22a"]
+
+[cols="a,a"]
 |===
 | 列挙型 | IfcTransportElementTypeEnum
 


### PR DESCRIPTION
fix overlapping text in tables

@Intelligent2013 would you please review my revisions and merge them if they are correct. i have checked with a local generate of the document. the columns widths are variable now on these corrected tables but the overlapping text is corrected. it may be necessary to revisit this in the future if we decide on some uniform column widths. thank you