### PR TITLE
fix: temporarily disable document validation due to Jing failure on Windows

### DIFF
--- a/sources/001-mds/document.adoc
+++ b/sources/001-mds/document.adoc
@@ -1,4 +1,5 @@
 = Standard Data Product Specification for 3D City Model
+:novalid:
 :docnumber: 1
 :edition: 4
 :revdate: 2024-03-22

--- a/sources/001-v3/document.adoc
+++ b/sources/001-v3/document.adoc
@@ -1,4 +1,5 @@
 = Handbook of 3D City Models
+:novalid:
 :docnumber: 1
 :edition: 3
 :revdate: 2023-12-25

--- a/sources/001-v4/document.adoc
+++ b/sources/001-v4/document.adoc
@@ -1,4 +1,5 @@
 = Standard Data Product Specification for 3D City Model
+:novalid:
 :docnumber: 1
 :edition: 4.1
 :revdate: 2024-09-30

--- a/sources/002-v4/document.adoc
+++ b/sources/002-v4/document.adoc
@@ -1,4 +1,5 @@
 = Standard Implementation Procedures for 3D City Model
+:novalid:
 :docnumber: 2
 :edition: 4
 :revdate: 2024-09-30


### PR DESCRIPTION
fix: temporarily disable document validation due to Jing failure on Windows

As per our call yesterday.