### PR TITLE
fix: loading plateau does not need "actions-mn/setup-flavor"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,13 +29,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Flavor
-        uses: actions-mn/setup-flavors@v1
-        with:
-          extra-flavors: plateau
-          github-pakages-token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-          use-bundler: true
-
       - name: Print Metanorma version
         run: metanorma --version
 
@@ -54,13 +47,6 @@ jobs:
   #       uses: actions/checkout@v4
   #       with:
   #         submodules: true
-
-  #     - name: Setup Flavor
-  #       uses: actions-mn/setup-flavors@v1
-  #       with:
-  #         extra-flavors: plateau
-  #         github-pakages-token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-  #         use-bundler: true
 
   #     - name: Print Metanorma version
   #       run: metanorma --version


### PR DESCRIPTION
Loading the plateau flavor no longer needs "actions-mn/setup-flavor".

Removing it here.