### PR TITLE
chore: GHA use bundler gems

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Bundler install
+        uses: metanorma/ci/docker-gem-install@main
+
       - name: Print Metanorma version
         run: metanorma --version
 


### PR DESCRIPTION
Attempting to use git gems for latest bug fixes, such as:
* #282 
* #299 