### PR TITLE
fix: revert ea diagrams from #278, it was not meant to be merged

### DIFF
--- a/sources/001-v5/document.adoc
+++ b/sources/001-v5/document.adoc
@@ -20,7 +20,7 @@
 :local-cache-only:
 :data-uri-image:
 
-[lutaml_ea_xmi,../xmi/plateau_all_packages_export.xmi]
+// [lutaml_ea_xmi,../xmi/plateau_all_packages_export.xmi]
 
 include::sections/change-history.adoc[]
 

--- a/sources/001-v5/sections/section-04/section-11.adoc
+++ b/sources/001-v5/sections/section-04/section-11.adoc
@@ -1243,18 +1243,18 @@ MultiSufaceを基本とする。
 [[toc4_11_02_01]]
 ===== Bridge（CityGML）
 
-lutaml_ea_diagram::[name="Bridge",base_path="./images",format="png"]
+// lutaml_ea_diagram::[name="Bridge",base_path="./images",format="png"]
 
-// image::images/EAID_30D62231_110F_44e8_9C06_6FCDCBA53A09.png[]
+image::images/EAID_30D62231_110F_44e8_9C06_6FCDCBA53A09.png[]
 
 // image::images/251.svg[]
 
 [[toc4_11_02_02]]
 ===== Urban Object（i-UR）
 
-lutaml_ea_diagram::[name="Bridgeの拡張属性",base_path="./images",format="png"]
+// lutaml_ea_diagram::[name="Bridgeの拡張属性",base_path="./images",format="png"]
 
-// image::images/EAID_EFBF5F0F_DF74_4944_8791_114F5637C335.png[]
+image::images/EAID_EFBF5F0F_DF74_4944_8791_114F5637C335.png[]
 
 // image::images/252.svg[]
 


### PR DESCRIPTION
Reverts #278 - this is the model-driven approach meant to be adopted afterwards. I merged it early on thinking there was no side effect.

FYI @ReesePlews .