### PR TITLE
fix: remove wrong title-intro-{en,ja} from 001-v5 and 002-v5

### DIFF
--- a/sources/001-v5/document.adoc
+++ b/sources/001-v5/document.adoc
@@ -5,12 +5,10 @@
 :published-date: 2026-03-19
 :copyright-year: 2026
 :language: ja
-:title-intro-ja: 3D都市モデル導入のためのガイドブック
 :title-main-ja: 3D都市モデル標準製品仕様書
+:title-main-en: Standard Data Product Specification for 3D City Model
 :publisher: 国土交通省　都市局
 :sponsor: （協力）内閣府　地方創生推進事務局
-:title-intro-en: Handbook of 3D City Models
-:title-main-en: Standard Data Product Specification for 3D City Model
 :doctype: handbook
 :coverpage-image: images/coverpage.png
 :imagedir: images

--- a/sources/002-v5/document.adoc
+++ b/sources/002-v5/document.adoc
@@ -5,12 +5,10 @@
 :published-date: 2026-03-19
 :copyright-year: 2026
 :language: ja
-:title-intro-ja: 3D都市モデル導入のためのガイドブック
 :title-main-ja: 3D都市モデル標準作業手順書
+:title-main-en: Standard Implementation Procedures for 3D City Model
 :publisher: 国土交通省　都市局
 :sponsor: （協力）内閣府　地方創生推進事務局
-:title-intro-en: Handbook of 3D City Models
-:title-main-en: Standard Implementation Procedures for 3D City Model
 :doctype: handbook
 :coverpage-image: images/coverpage.pdf
 :imagedir: images


### PR DESCRIPTION
Related to metanorma/metanorma-plateau#296

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
