### PR TITLE
fix(ci): use build-and-publish@v2 with unified workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,8 +19,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: metanorma/metanorma:latest
+    # container:
+    #   image: metanorma/metanorma:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Update `generate.yml` to use multi-platform testing (ubuntu, windows, macos)
- Update `docker.yml` to use `build-and-publish@v2` with conditional deploy
- Deploy only happens for public repos (via `visibility` check)

## Test plan
- [ ] Verify generate.yml runs on all 3 platforms
- [ ] Verify docker.yml builds successfully
- [ ] Verify deploy step is conditionally executed based on repo visibility